### PR TITLE
Add a job to validate the CSS and fix the CSS

### DIFF
--- a/.github/workflows/validate-css.yml
+++ b/.github/workflows/validate-css.yml
@@ -1,0 +1,13 @@
+name: Validate CSS
+
+on: [push, pull_request]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+      - run: npx -y csstree-validator css/flat-remix.css

--- a/.github/workflows/validate-css.yml
+++ b/.github/workflows/validate-css.yml
@@ -1,6 +1,6 @@
 name: Validate CSS
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   validate:

--- a/css/flat-remix.css
+++ b/css/flat-remix.css
@@ -188,7 +188,7 @@ code, pre {
     line-height: 2em;
     cursor: auto;
     user-select: text;
-    -webkit-touch-callout: text;
+    -webkit-touch-callout: default;
     -webkit-user-select: text;
 }
 
@@ -213,7 +213,7 @@ textarea, select {
     font-weight: bold;
     cursor: text;
     user-select: text;
-    -webkit-touch-callout: text;
+    -webkit-touch-callout: default;
     -webkit-user-select: text;
 }
 
@@ -494,6 +494,6 @@ input[type=reset]:active, input[type=reset].active,
 .selectable {
     cursor: auto;
     user-select: text;
-    -webkit-touch-callout: text;
+    -webkit-touch-callout: default;
     -webkit-user-select: text;
 }


### PR DESCRIPTION
I like seeing green checkboxes next to repos, so why not add a CSS validator job to validate this repo? :)

The job found this invalid CSS CSS: `-webkit-touch-callout: text;`

I fixed this by changing it into `-webkit-touch-callout: default;`

Alternatively, we could stop doing this altogether by removing the lines with this and the global `-webkit-touch-callout: none` as well. I didn't want to do a full investigation of why you'd want this or not, so I just fixed the CSS instead.